### PR TITLE
Allow usage from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ import { mode } from "https://raw.githubusercontent.com/denorg/starter/master/mo
 const result = mode();
 ```
 
+You can also run the script from the command line using:
+```bash
+deno run --allow-read https://raw.githubusercontent.com/denorg/starter/master/cli.ts <arguments>
+```
+Or install using
+```bash
+deno install --allow-read -n starter https://raw.githubusercontent.com/denorg/starter/master/cli.ts
+```
+and run with
+```bash
+starter <arguments>
+```
+
 Required permissions:
 
 1. `--allow-read`

--- a/cli.ts
+++ b/cli.ts
@@ -1,4 +1,4 @@
-import { mode } from "./mod.ts"
+import { mode } from "./mod.ts";
 
 for (let arg of Deno.args) {
   console.log(arg, mode());

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,5 @@
+import { mode } from "./mod.ts"
+
+for (let arg of Deno.args) {
+  console.log(arg, mode());
+}


### PR DESCRIPTION
Add `cli.ts` that can be ran (with `deno run --<permission> https://raw.githubusercontent.com/denorg/starter/master/cli.ts <arguments>`) or installed (with `deno install --<permission> -n starter https://raw.githubusercontent.com/denorg/starter/master/cli.ts` and ran with `starter <aguments>`).

I'm not sure if this should be using a separate file or should be added to `mod.ts`, but my argument for the separation is that `mod.ts` is usually named so because it's a module file that exports everything from the package, not necessarily runs it. And the changes should be easier to implement in existing repositories, since they won't need to change `mod.ts` but just add `cli.ts`. And if someone wants to add a better argument parser like [cliffy](https://deno.land/x/cliffy) or [denomander](https://deno.land/x/denomander) this import isn't used if someone just wants to import the functions from `mod.ts` to their code.