### PR TITLE
:wrench: Add Deno VS Code extension settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "deno.enable": true
+}


### PR DESCRIPTION
The [Deno VS Code extension](https://marketplace.visualstudio.com/items?itemName=axetroy.vscode-deno) suggested by the [manual](https://deno.land/manual/getting_started/setup_your_environment#editors-and-ides) recommends to enable it per project.

Either this or adding a `.gitignore` file for ignoring `.vscode`.

